### PR TITLE
second try for commit of BIDS diagram

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@quasar/extras": "^1.16.4",
+    "mind-elixir": "^4.5.2",
     "quasar": "^2.16.0",
     "vue": "^3.4.18",
     "vue-router": "^4.0.12"
@@ -46,5 +47,6 @@
     "node": "^20 || ^18 || ^16",
     "npm": ">= 6.13.4",
     "yarn": ">= 1.21.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/frontend/src/pages/BIDSMindMap.vue
+++ b/frontend/src/pages/BIDSMindMap.vue
@@ -1,0 +1,178 @@
+<template>
+    <div id="map"></div>
+  </template>
+  
+  <script setup lang="ts">
+  import MindElixir from 'mind-elixir';
+  import { onMounted, ref } from 'vue';
+  
+  const me = ref();
+  
+  const customData = {
+    nodeData: {
+      id: 'root',
+      topic: 'BIDS',
+      children: [
+        {
+          id: 'child1',
+          topic: 'Humans/Community',
+          expanded: false,
+          children: [
+            { id: 'child1a', topic: 'Code of Conduct' },
+            { id: 'child1b', topic: 'Contributing Guidelines' },
+            { id: 'child1c', topic: 'Decision Making' },
+            {
+              id: 'child1d',
+              topic: 'Licenses',
+              expanded: false,
+              children: [
+                {
+                  id: 'child1di',
+                  topic: 'CC-BY-4.0',
+                  hyperLink: 'https://creativecommons.org/licenses/by/4.0/',
+                },
+                { id: 'child1dii', topic: 'MIT' },
+              ],
+            },
+            { id: 'child1e', topic: 'RFC 2119 terms: REQUIRED, ...' },
+            {
+              id: 'child1f',
+              topic: 'Inspired via OpenNeuro, the "Ultimated OBC"',
+              expanded: false,
+              children: [
+                {
+                  id: 'child1fi',
+                  topic: ' Open Brain Consent Form',
+                  hyperLink: 'https://open-brain-consent.readthedocs.io/en/latest/ultimate.html',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'child2',
+          topic: 'File formats',
+          expanded: false,
+          children: [
+            {
+              id: 'child2a',
+              topic: 'Encodings',
+              expanded: false,
+              children: [
+                { id: 'child2ai', topic: 'ASCII' },
+                { id: 'child2aii', topic: 'UTF-8' },
+                { id: 'child2aiii', topic: 'RFC 3339 (date time)' },
+                { id: 'child2aiv', topic: 'CMIXF-12 (units)' },
+              ],
+            },
+            { id: 'child2b', topic: 'HED' },
+            {
+              id: 'child2c',
+              topic: 'JSON',
+              expanded: false,
+              children: [{ id: 'child2ci', topic: 'YAML' }],
+            },
+            { id: 'child2d', topic: 'Markdown' },
+            { id: 'child2e', topic: 'NIfTI' },
+            {
+              id: 'child2f',
+              topic: 'NWB',
+              expanded: false,
+              children: [{ id: 'child2fi', topic: 'HDF5' }],
+            },
+            { id: 'child2g', topic: 'OME Zarr' },
+            { id: 'child2h', topic: 'TSV' },
+          ],
+        },
+        {
+          id: 'child6',
+          topic: 'BEPs',
+          expanded: false,
+          children: [
+            { id: 'child6a', topic: 'BEP001' },
+            { id: 'child6b', topic: 'BEP026' },
+          ],
+        },
+        {
+          id: 'child3',
+          topic: 'Metadata',
+          expanded: false,
+          children: [
+            { id: 'child3a', topic: 'DICOM' },
+            { id: 'child3b', topic: 'HED' },
+            { id: 'child3c', topic: 'Cognitive Atlas' },
+            { id: 'child3d', topic: 'CogPo' },
+          ],
+        },
+        {
+          id: 'child5',
+          topic: 'File system',
+          expanded: false,
+          children: [
+            { id: 'child5a', topic: 'Filename (>8.3)' },
+            { id: 'child5b', topic: 'Folder (circa 1958)' },
+          ],
+        },
+        {
+          id: 'child4',
+          topic: 'Automation/CI',
+          expanded: false,
+          children: [
+            {
+              id: 'child4a',
+              topic: 'Circle CI',
+              expanded: false,
+              children: [
+                { id: 'child4ai', topic: 'build' },
+                { id: 'child4aii', topic: 'linkcheck' },
+              ],
+            },
+            {
+              id: 'child4b',
+              topic: 'GitHub',
+              expanded: false,
+              children: [
+                { id: 'child4bi', topic: 'codespell' },
+                { id: 'child4bii', topic: 'no bad latin' },
+                { id: 'child4bi', topic: '...more to catch human errors...' },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'child7',
+          topic: 'Network',
+          expanded: false,
+          children: [
+            {
+              id: 'child7a',
+              topic: 'HTTP',
+              expanded: false,
+              children: [
+                { id: 'child7ai', topic: 'TCP' },
+                { id: 'child7aii', topic: 'IP' },
+              ],
+            },
+            { id: 'child7b', topic: 'RFC 3986 (URI)' },
+          ],
+        },
+      ],
+    },
+    linkData: {},
+    expand: {},
+  };
+  
+  onMounted(() => {
+    me.value = new MindElixir({
+      el: '#map',
+      direction: MindElixir.SIDE,
+    });
+    me.value.init(customData);
+  });
+  </script>
+  <style>
+  #map {
+    width: 100%;
+    height: calc(100vh - 195px);
+  }
+  </style>  

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -38,6 +38,10 @@ const routes: RouteRecordRaw[] = [
         path: 'tos',
         component: () => import('pages/TermsOfService.vue'),
       },
+      {
+        path: 'BIDS-mindmap',
+        component: () => import('pages/BIDSMindMap.vue'),
+      },
     ],
   },
   // Always leave this as last one,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2647,6 +2647,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mind-elixir@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/mind-elixir/-/mind-elixir-4.5.2.tgz#e1c75d5072b55d57cae3d6609a1d5bd609c6db33"
+  integrity sha512-PWPxspV56kdnR4PZ90QdCIPn4ckfHx/o6LTvtlHtlZNVhod5nCjFFFTp+28+wclmf2fg0+gOWU+bCGjrD6vv2Q==
+
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"


### PR DESCRIPTION
--> new PR from branch rather than forked repo
--> from @NEStock on last PR
- Suggestion: Add link via tabs

Currently this page is only available the direct URL, but I think it would be great to make it more accessible to users. Any thoughts on where a good place would be? Perhaps a dropdown one of the existing tabs?

in my opinion, a dropdown tab under "metadata" feels like the closest fit but not quite right. one idea might be changing metadata -> "Data Model" and then adding a tab underneath for "BIDS" or something.

Definitely open to other suggestions!

@guittari curious if you have thoughts on this as well

-it might also make sense to add some details and/or links about:

what is BIDS & why is it import for EMBER
link/reference to the original diagram

- added new yarn lock for this PR!
- fixed height 
- renamed direct URL to BIDS-mindmap
